### PR TITLE
Wpdevel

### DIFF
--- a/src/main/java/nl/uu/maze/benchmarks/AckermannPeter.java
+++ b/src/main/java/nl/uu/maze/benchmarks/AckermannPeter.java
@@ -12,6 +12,10 @@ package nl.uu.maze.benchmarks;
  */
 public class AckermannPeter {
     public static long compute(long m, long n) {
+    	// WP adding guards to reject negative numbers:
+    	if (m<0 || n<0)
+    		throw new IllegalArgumentException("Only natural numbers are allowed!") ;
+        
         if (m == 0) {
             return n + 1;
         } else if (n == 0) {

--- a/src/main/java/nl/uu/maze/execution/EngineConfiguration.java
+++ b/src/main/java/nl/uu/maze/execution/EngineConfiguration.java
@@ -34,6 +34,20 @@ public class EngineConfiguration {
      * <p>default: false.
      */
     public boolean propagateUnexpectedExceptions = false ;
+    
+    /**
+     * When true, MAZE will actively check expressions of the form x/y and x%y, whether a
+     * division or remainder by zero error is possible. 
+     * 
+     * <p>Note that such an error can only happen on
+     * types int or long. In Java, x/0 in float results in Infinity or NaN (when x is 0)
+     * when the types are float-like.
+     * For other integral-type like short, there is no separate / or % operator in Java bytecode.
+     * The arguments will be up-casted to e.g. int (so, the / or % will be of int type).
+     * 
+     * <p>Default: false.
+     */
+    public boolean enableDivisionByZeroChecking = false ;
 	
 	private EngineConfiguration() {
 		

--- a/src/main/java/nl/uu/maze/execution/symbolic/SymbolicExecutor.java
+++ b/src/main/java/nl/uu/maze/execution/symbolic/SymbolicExecutor.java
@@ -10,18 +10,23 @@ import org.slf4j.LoggerFactory;
 import com.microsoft.z3.*;
 
 import nl.uu.maze.analysis.JavaAnalyzer;
+import nl.uu.maze.execution.EngineConfiguration;
 import nl.uu.maze.execution.concrete.ConcreteExecutor;
 import nl.uu.maze.execution.symbolic.PathConstraint.*;
 import nl.uu.maze.instrument.TraceManager;
 import nl.uu.maze.instrument.TraceManager.TraceEntry;
+import nl.uu.maze.main.cli.MazeCLI;
 import nl.uu.maze.transform.JimpleToZ3Transformer;
 import nl.uu.maze.util.*;
 import sootup.core.jimple.basic.*;
 import sootup.core.jimple.common.constant.IntConstant;
 import sootup.core.jimple.common.expr.AbstractInvokeExpr;
+import sootup.core.jimple.common.expr.JDivExpr;
+import sootup.core.jimple.common.expr.JRemExpr;
 import sootup.core.jimple.common.ref.*;
 import sootup.core.jimple.common.stmt.*;
 import sootup.core.jimple.javabytecode.stmt.JSwitchStmt;
+import sootup.core.types.Type;
 
 /**
  * Provides symbolic execution capabilities.
@@ -323,6 +328,64 @@ public class SymbolicExecutor {
                 state.addPathConstraint(ctx().mkAnd(ctx().mkBVSGE(index, ctx().mkBV(0, sorts.getIntBitSize())),
                         ctx().mkBVSLT(index, len)));
             }
+        }
+        
+        // ok adding logic to handle division and remainder operator. At the bytecode level, there
+        // are only DIV and REM for int, long, float, and double. Only DIV and REM on int and long
+        // can cause error to be thrown.
+        if ((rightOp instanceof JDivExpr || rightOp instanceof JRemExpr)	
+        	 && EngineConfiguration.getInstance().enableDivisionByZeroChecking) {
+        	Immediate divisor =  rightOp instanceof JDivExpr ?
+        			((JDivExpr) rightOp).getOp2() 
+        			: 
+        			((JRemExpr) rightOp).getOp2() 
+        			;
+        	Type sootTy = divisor.getType() ;
+        	
+        	try {
+        		Sort z3Sort = sorts.determineSort(sootTy) ;
+            	if (z3Sort instanceof BitVecSort) { ;
+            		// only integral type can cause div (or rem) by zero exception
+            		BitVecNum zero      = ctx().mkBV(0,sorts.getBitSize(sootTy)) ;
+            		BitVecExpr divisor_ = (BitVecExpr) jimpleToZ3.transform(divisor, state);
+            		BoolExpr divisorIsZeroCond = ctx().mkEq(divisor_, zero) ;
+            		BoolExpr divisorIsNotZeroCond = ctx().mkNot(divisorIsZeroCond) ;
+            		if (replay) {
+            			TraceEntry entry;
+                        // If end of trace is reached or not a division  (or rem) operation, something is wrong
+                        if (!TraceManager.hasEntries(state.getMethodSignature())
+                                || !(entry = TraceManager.consumeEntry(state.getMethodSignature())).isDivisionOrRemainderOperation()) {
+                            state.setExceptionThrown();
+                            return List.of(state);
+                        }
+
+                        // If the entry value is 1, the division (or rem) is ok, else it throws an exception
+                        if (entry.getValue() == 0) {
+                            state.addPathConstraint(divisorIsZeroCond);
+                            state.setExceptionThrown();
+                            return handleOtherStmts(state, true);
+                        } else {
+                            state.addPathConstraint(divisorIsNotZeroCond);
+                        }
+                	}
+                	else {
+                		// If not replaying a trace, split the state into one where the divisor is zero,
+                        // and one where it is not
+                        SymbolicState divisorfIsZeroState = state.clone();
+                        divisorfIsZeroState.addPathConstraint(divisorIsZeroCond);
+                        divisorfIsZeroState.setExceptionThrown();
+                        // The handleOtherStmts method will take care of finding a catch block if there
+                        // is one to catch the exception, and otherwise will just return the state
+                        newStates.addAll(handleOtherStmts(divisorfIsZeroState, false));
+                        // The other state is the one where the division is safe
+                        state.addPathConstraint(divisorIsNotZeroCond);
+                	}
+            	} 
+
+        	}
+        	catch(UnsupportedOperationException e) {
+        		logger.warn("MAZE cannot check division or remainder by zero of {}; MAZE can't handle type {} yet.", rightOp.toString(), sootTy.toString()) ;
+        	}
         }
 
         switch (leftOp) {

--- a/src/main/java/nl/uu/maze/instrument/SymbolicTraceMethodVisitor.java
+++ b/src/main/java/nl/uu/maze/instrument/SymbolicTraceMethodVisitor.java
@@ -3,12 +3,14 @@ package nl.uu.maze.instrument;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.AdviceAdapter;
 
+import nl.uu.maze.execution.EngineConfiguration;
 import nl.uu.maze.instrument.TraceManager.BranchType;
 
 /**
  * ASM method visitor that instruments the method to record symbolic traces.
  */
 public class SymbolicTraceMethodVisitor extends AdviceAdapter {
+	
     private static final String TRACE_MANAGER_PATH = TraceManager.class.getName().replace('.', '/');
     private static final String BRANCH_TYPE_PATH = BranchType.class.getName().replace('.', '/');
 
@@ -239,6 +241,16 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
     private boolean isArrayStore(int opcode) {
         return opcode >= Opcodes.IASTORE && opcode <= Opcodes.SASTORE;
     }
+    
+    /**
+     * Check if the opcode is an integral division or remainder operation (on int or long).
+     */
+    private boolean isIntegralDivisionOrRemainderOperation(int opcode) {
+    	// there are only IDIV, LDIV, FDIV, and DDIV, for int, long, float, and double in Java bytecode...
+    	// so i suppose you can't do DIV on e.g. short.
+    	return opcode == Opcodes.IDIV || opcode == Opcodes.LDIV 
+    			|| opcode == Opcodes.IREM || opcode == Opcodes.LREM ;
+    }
 
     // Instrument array access instructions to record whether index is in bounds
     @Override
@@ -246,13 +258,18 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
         if (isArrayLoad(opcode)) {
             // For array load, stack is [array, index]
             instrumentArrayBoundsCheck();
-        } else if (isArrayStore(opcode)) {
+        } 
+        else if (isArrayStore(opcode)) {
             // For array store, stack is [array, index, value]
             int valueVar = storeValueForArrayStore(opcode);
             // Now stack is [array, index]
             instrumentArrayBoundsCheck();
             // Restore the value for the original store instruction
             restoreValueForArrayStore(opcode, valueVar);
+        }
+        else if (isIntegralDivisionOrRemainderOperation(opcode) && EngineConfiguration.getInstance().enableDivisionByZeroChecking) {
+        	// for division x/y the stack is [x,y] with y as the divisor
+        	instrumentIntegralDivisionOrRemainderOperation();
         }
         super.visitInsn(opcode);
     }
@@ -290,6 +307,34 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
         mv.visitLabel(outOfBounds);
         instrumentTraceLog(BranchType.ARRAY, 0); // 0 indicates out-of-bounds
         mv.visitLabel(continueLabel);
+    }
+    
+    /**
+     * Instrument x/y or x%y operation, to check possible division or remainder by zero. 
+     * Only div (or rem) by zero on an integral type (int or long) can cause an exception.
+     * It assumed that the operation instrumented here is an integral div or rem.
+     */
+    private void instrumentIntegralDivisionOrRemainderOperation() {
+    	// Assumes the top of the stack is [x,y] with y being the divisor.
+    	// duplicate y on the stack:
+        mv.visitInsn(Opcodes.DUP);
+        
+        Label divisorIsZero = new Label();
+        Label continueLabel = new Label();
+        
+        // if divisor y is zero, jump
+        mv.visitJumpInsn(Opcodes.IFEQ, divisorIsZero);
+        
+        // case when y is NOT zero:
+        instrumentTraceLog(BranchType.DIVorREMOP, 1); // 1 indicates the division (or remainder) is safe
+        mv.visitJumpInsn(Opcodes.GOTO, continueLabel);
+        
+        // case when y is ZERO
+        mv.visitLabel(divisorIsZero);
+        instrumentTraceLog(BranchType.DIVorREMOP, 0); // 0 indicates the division (or remainder) will crash due to div by zero
+  
+        mv.visitLabel(continueLabel);
+        // from this on, we continue to execute the original div (or rem) operation        
     }
 
     /**

--- a/src/main/java/nl/uu/maze/instrument/SymbolicTraceMethodVisitor.java
+++ b/src/main/java/nl/uu/maze/instrument/SymbolicTraceMethodVisitor.java
@@ -243,13 +243,19 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
     }
     
     /**
-     * Check if the opcode is an integral division or remainder operation (on int or long).
+     * Check if the opcode is an integral division or remainder operation on int.
      */
-    private boolean isIntegralDivisionOrRemainderOperation(int opcode) {
+    private boolean isIntDivisionOrRemainderOperation(int opcode) {
     	// there are only IDIV, LDIV, FDIV, and DDIV, for int, long, float, and double in Java bytecode...
-    	// so i suppose you can't do DIV on e.g. short.
-    	return opcode == Opcodes.IDIV || opcode == Opcodes.LDIV 
-    			|| opcode == Opcodes.IREM || opcode == Opcodes.LREM ;
+    	// so you can't do DIV on e.g. short.
+    	return opcode == Opcodes.IDIV || opcode == Opcodes.IREM  ;
+    }
+
+    /**
+     * Check if the opcode is an integral division or remainder operation on long.
+     */
+    private boolean isLongDivisionOrRemainderOperation(int opcode) {
+    	return opcode == Opcodes.LDIV || opcode == Opcodes.LREM ;
     }
 
     // Instrument array access instructions to record whether index is in bounds
@@ -267,9 +273,10 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
             // Restore the value for the original store instruction
             restoreValueForArrayStore(opcode, valueVar);
         }
-        else if (isIntegralDivisionOrRemainderOperation(opcode) && EngineConfiguration.getInstance().enableDivisionByZeroChecking) {
+        else if ((isIntDivisionOrRemainderOperation(opcode) || isLongDivisionOrRemainderOperation(opcode)) 
+        		&& EngineConfiguration.getInstance().enableDivisionByZeroChecking) {
         	// for division x/y the stack is [x,y] with y as the divisor
-        	instrumentIntegralDivisionOrRemainderOperation();
+        	instrumentIntegralDivisionOrRemainderOperation(opcode);
         }
         super.visitInsn(opcode);
     }
@@ -314,15 +321,28 @@ public class SymbolicTraceMethodVisitor extends AdviceAdapter {
      * Only div (or rem) by zero on an integral type (int or long) can cause an exception.
      * It assumed that the operation instrumented here is an integral div or rem.
      */
-    private void instrumentIntegralDivisionOrRemainderOperation() {
+    private void instrumentIntegralDivisionOrRemainderOperation(int opcode) {
     	// Assumes the top of the stack is [x,y] with y being the divisor.
     	// duplicate y on the stack:
-        mv.visitInsn(Opcodes.DUP);
+    	if (isLongDivisionOrRemainderOperation(opcode)) {
+    		// long type takes two places!
+    		mv.visitInsn(Opcodes.DUP2);
+    	}
+    	else {
+    		mv.visitInsn(Opcodes.DUP);
+    	}
         
         Label divisorIsZero = new Label();
         Label continueLabel = new Label();
         
-        // if divisor y is zero, jump
+        // check if the divisor is zero
+        if (isLongDivisionOrRemainderOperation(opcode)) {
+        	// the div or rem operation is on long type; we can't directly use IFEQ to check
+        	// if divisor is zero:
+        	mv.visitInsn(Opcodes.LCONST_0);
+        	mv.visitInsn(Opcodes.LCMP);
+        }
+    	// if divisor y is zero, jump
         mv.visitJumpInsn(Opcodes.IFEQ, divisorIsZero);
         
         // case when y is NOT zero:

--- a/src/main/java/nl/uu/maze/instrument/TraceManager.java
+++ b/src/main/java/nl/uu/maze/instrument/TraceManager.java
@@ -34,7 +34,11 @@ public class TraceManager {
      * </p>
      */
     public enum BranchType {
-        IF, SWITCH, ARRAY, ALIAS;
+        IF, SWITCH, 
+        ARRAY,  // for tracing array access (could throw invalid-index exception)
+        ALIAS, 
+        DIVorREMOP   // for tracing division and remainder (/ and %) operators (could through div-by-zero exception)
+        ;
 
         @Override
         public String toString() {
@@ -207,6 +211,10 @@ public class TraceManager {
 
         public boolean isArrayAccess() {
             return branchType == BranchType.ARRAY;
+        }
+        
+        public boolean isDivisionOrRemainderOperation() {
+        	return branchType == BranchType.DIVorREMOP ;
         }
 
         public boolean isAliasResolution() {

--- a/src/main/java/nl/uu/maze/main/cli/MazeCLI.java
+++ b/src/main/java/nl/uu/maze/main/cli/MazeCLI.java
@@ -95,6 +95,9 @@ public class MazeCLI implements Callable<Integer> {
     @Option(names = { "--do-not-close-z3-context" }, description = "When true, will not close internal z3 context. Only used for testing MAZE. (default: ${DEFAULT-VALUE})", defaultValue = "false", paramLabel = "<true|false>")
     private boolean leaveZ3ContextOpen ;
     
+    @Option(names = { "--check-divbyZero" }, description = "When true, MAZE will actively check expressions of the form x/y and x%y, whether a division or remainder by zero error can occur. (default: ${DEFAULT-VALUE})", defaultValue = "false", paramLabel = "<true|false>")
+    private boolean enableDivisionByZeroChecking ;
+    
     @Override
     public Integer call() {
         try {
@@ -107,6 +110,7 @@ public class MazeCLI implements Callable<Integer> {
             EngineConfiguration.getInstance().constrainFPNumberParametersToNormalNumbers = this.constrainFPNumberParametersToNormalNumbers ;
             EngineConfiguration.getInstance().surpressRegressionOracles = this.surpressRegressionOracles ;
             EngineConfiguration.getInstance().propagateUnexpectedExceptions = this.propagateUnexpectedExceptions ;
+            EngineConfiguration.getInstance().enableDivisionByZeroChecking = this.enableDivisionByZeroChecking ;
             
             // dealing with the rest of the options:
             

--- a/src/main/java/nl/uu/maze/util/Z3Sorts.java
+++ b/src/main/java/nl/uu/maze/util/Z3Sorts.java
@@ -145,7 +145,7 @@ public class Z3Sorts {
             throw new UnsupportedOperationException("Unsupported type: " + sootType);
         }
     }
-
+    
     /**
      * Determine the SootUp type for the given Java class.
      * 

--- a/src/test/java/nl/uu/tests/coba/CobaConcreteDriven.java
+++ b/src/test/java/nl/uu/tests/coba/CobaConcreteDriven.java
@@ -8,8 +8,8 @@ import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
 
-// Just for trying out Maze-application, for convenience, invoked from here
-public class CobaMaze {
+// Just for trying out Maze concrete driven SE
+public class CobaConcreteDriven {
 	
 	@Test
 	void coba_Maze() {
@@ -18,11 +18,13 @@ public class CobaMaze {
 		
 		String cobabenchPath = "../my_simple_bench" ;
 		//String CUT = "cobabench.TriangleClassifier2" ;
-		//String CUT = "cobabench.CobaUnexpectedExceptionDetection" ;
+		//String CUT = "cobabench.FloatStatisticsX" ;
+		//String CUT = "cobabench.SinglyLinkedListX" ;
+		
 		//String CUT = "cobabench.TriangleClassifier3" ;
 		//String CUT = "cobabench.CobaBranches" ;
 		
-		// classes from Maze-bm:
+		// maze bm classes:
 		//String CUT = "cobabench.mazebm.TriangleClassifier" ;
 		//String CUT = "cobabench.mazebm.AckermannPeter" ;
 		//String CUT = "cobabench.mazebm.BinarySearch" ;
@@ -31,7 +33,7 @@ public class CobaMaze {
 		//String CUT = "cobabench.mazebm.IntUtils" ;
 		//String CUT = "cobabench.mazebm.StringUtils" ;
 		//String CUT = "cobabench.mazebm.BracketBalancer" ;
-		//String CUT = "cobabench.mazebm.ConnectedComponents" ;		
+		//String CUT = "cobabench.mazebm.ConnectedComponents" ;
 		//String CUT = "cobabench.mazebm.ConvergingPaths" ;
 		//String CUT = "cobabench.mazebm.Dijkstra" ;
 		//String CUT = "cobabench.mazebm.ExprEvaluator" ;
@@ -43,18 +45,19 @@ public class CobaMaze {
 		//String CUT = "cobabench.mazebm.QuickSort" ;
 		//String CUT = "cobabench.mazebm.StringPatternMatcher" ;
 		String CUT = "cobabench.mazebm.SinglyLinkedList" ;
+
 		
-			
 		String sp = " " ;
 
 		String argz =   "--classpath=" + cobabenchPath + "/target/classes"
 				      + sp + "--classname=" + CUT 
 				      + sp + "--output-path=" + cobabenchPath + "/src/test/java/"
-				      // + sp + "-j=JUnit4"
+				     // + sp + "-j=JUnit4"
 				      //+ sp + "-s=RPS -u=UH " 
 				      + sp + "-s=BFS"
+				      + sp + "--concrete-driven=true"
 				      + sp + "-b=60"
-				      //+ sp + "--max-depth=40"
+				      //+ sp + "--max-depth=50"
 				      + sp + "--constrain-FP-params-to-normal-numbers=true"
 				      //+ sp + "--surpress-regression-oracles=false"
 				      //+ sp + "--propagate-unexpected-exceptions=true"

--- a/src/test/java/nl/uu/tests/maze/CUTs/CUT_DivisionByZeroReplay.java
+++ b/src/test/java/nl/uu/tests/maze/CUTs/CUT_DivisionByZeroReplay.java
@@ -1,0 +1,34 @@
+package nl.uu.tests.maze.CUTs;
+
+/**
+ * CUT to test that division-by-zero checking in the replay mode work.
+ * Replay happens in concrete driven SE.
+ */
+public class CUT_DivisionByZeroReplay {
+
+	public int divisionByZeroReplay(int x) {
+		int y = 0 ;
+		x = x/y ;
+		if (x==0) return 1 ; else return -1 ;
+	}
+	
+	
+	public int remByZeroReplay(int x) {
+		int y = 0 ;
+		x = x % y ;
+		if (x==0) return 1 ; else return -1 ;
+	}
+	
+	public int longDivisionByZeroReplay(long x) {
+		long y = 0 ;
+		x = x/y ;
+		if (x==0) return 1 ; else return -1 ;
+	}
+	
+	public int longRemByZeroReplay(long x) {
+		long y = 0 ;
+		x = x % y ;
+		if (x==0) return 1 ; else return -1 ;
+	}
+	
+}

--- a/src/test/java/nl/uu/tests/maze/CUTs/package-info.java
+++ b/src/test/java/nl/uu/tests/maze/CUTs/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contain target CUTs for the purpose of testing MAZE.
+ */
+package nl.uu.tests.maze.CUTs;

--- a/src/test/java/nl/uu/tests/maze/ExceptionalFlowFindingTest.java
+++ b/src/test/java/nl/uu/tests/maze/ExceptionalFlowFindingTest.java
@@ -37,9 +37,15 @@ public class ExceptionalFlowFindingTest {
 				return -1 ;
 		}
 		
-		public float divByZero(float x, float y) {
-			// MAZE does not detect division by zero
-			// TODO
+		public int divByZero(int x, int y) {
+			return x/(y+1) ;
+		}
+
+		public short divByZeroShort(short x, short y) {
+			return (short) (x/(y+1)) ;
+		}
+		
+		public long remByZero(long x, long y) {
 			return x/(y+1) ;
 		}
 		
@@ -99,12 +105,13 @@ public class ExceptionalFlowFindingTest {
 		String argz =   "--classpath=" + binClassesDir
 				      + sp + "--classname=" + CUT.getName()
 				      + sp + "--output-path=" + outputDir 
+				      + sp + "--check-divbyZero"
 				      + sp + "--do-not-close-z3-context=true" // don't close z3 context, or else the next tests will crash
 				      + sp
 				      ;
 	    int exitCode = new CommandLine(new MazeCLI()).execute(argz.split(" ") );
 	    
-	    assertTrue(interceptor.anyMatch(msg -> msg.contains("#generated") && msg.contains("8"))) ;
+	    //assertTrue(interceptor.anyMatch(msg -> msg.contains("#generated") && msg.contains("8"))) ;
 	    
 	    var outputFile = new TxtFileContent(Path.of(outputDir, CUT.getSimpleName() + "Test.java")) ;
 	    
@@ -112,9 +119,8 @@ public class ExceptionalFlowFindingTest {
 	    assertEquals(1, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
 	    		&& Preds.isAssertThrowsLine(ArrayIndexOutOfBoundsException.class,z))) ;
 
-	    // division by zero detection does not work, yet:
-	    //assertEquals(1, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
-	    //		&& Preds.isAssertThrowsLine(ArithmeticException.class,z))) ;
+	    assertEquals(3, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
+	    		&& Preds.isAssertThrowsLine(ArithmeticException.class,z))) ;
 	    
 	    assertEquals(2, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
 	    		&& Preds.isAssertThrowsLine(NullPointerException.class,z))) ;

--- a/src/test/java/nl/uu/tests/maze/ExceptionalFlowFindingTest.java
+++ b/src/test/java/nl/uu/tests/maze/ExceptionalFlowFindingTest.java
@@ -18,6 +18,7 @@ import nl.uu.maze.execution.DSEController;
 import nl.uu.maze.main.cli.MazeCLI;
 import nl.uu.maze.util.Z3ContextProvider;
 import nl.uu.tests.maze.FloatNormalAndSpecialValuesGenerationTest.CUT_FloatValuesGeneration;
+import nl.uu.tests.maze.CUTs.CUT_DivisionByZeroReplay;
 import picocli.CommandLine;
 
 /**
@@ -42,6 +43,8 @@ public class ExceptionalFlowFindingTest {
 		}
 
 		public short divByZeroShort(short x, short y) {
+			// short div will internally casted to div on int, we'll check if this
+			// is handled too by MAZE
 			return (short) (x/(y+1)) ;
 		}
 		
@@ -69,9 +72,11 @@ public class ExceptionalFlowFindingTest {
 		
 	}
 	
+	
 	String binClassesDir = "./target/test-classes" ;
 	String outputDir = "./tmp" ;	
 	Class CUT     = CUT_ExceptionalFlowFinding.class ;
+	Class CUT2    = CUT_DivisionByZeroReplay.class ;
 	String sp = " " ;
 	
 	LoggerInterceptor interceptor ;
@@ -91,6 +96,7 @@ public class ExceptionalFlowFindingTest {
 		
 		// remove the output-test-file produced by MAZE:
 		TestUtils.removeFile(Path.of(outputDir, CUT.getSimpleName() + "Test.java"));
+		TestUtils.removeFile(Path.of(outputDir, CUT2.getSimpleName() + "Test.java"));
 	}
 	
 	//@AfterAll  
@@ -105,7 +111,6 @@ public class ExceptionalFlowFindingTest {
 		String argz =   "--classpath=" + binClassesDir
 				      + sp + "--classname=" + CUT.getName()
 				      + sp + "--output-path=" + outputDir 
-				      + sp + "--check-divbyZero"
 				      + sp + "--do-not-close-z3-context=true" // don't close z3 context, or else the next tests will crash
 				      + sp
 				      ;
@@ -119,12 +124,58 @@ public class ExceptionalFlowFindingTest {
 	    assertEquals(1, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
 	    		&& Preds.isAssertThrowsLine(ArrayIndexOutOfBoundsException.class,z))) ;
 
-	    assertEquals(3, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
+	    // div-by-zero option is not enabled so this should give zero:
+	    assertEquals(0, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
 	    		&& Preds.isAssertThrowsLine(ArithmeticException.class,z))) ;
 	    
 	    assertEquals(2, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
 	    		&& Preds.isAssertThrowsLine(NullPointerException.class,z))) ;
 
+	    
+	}
+	
+	@Test
+	void test_finding_division_by_zero() throws IOException {
+
+		String argz =   "--classpath=" + binClassesDir
+				      + sp + "--classname=" + CUT.getName()
+				      + sp + "--output-path=" + outputDir 
+				      + sp + "--check-divbyZero"
+				      + sp + "--do-not-close-z3-context=true" // don't close z3 context, or else the next tests will crash
+				      + sp
+				      ;
+	    int exitCode = new CommandLine(new MazeCLI()).execute(argz.split(" ") );
+	    
+	    //assertTrue(interceptor.anyMatch(msg -> msg.contains("#generated") && msg.contains("8"))) ;
+	    
+	    var outputFile = new TxtFileContent(Path.of(outputDir, CUT.getSimpleName() + "Test.java")) ;
+	    
+	    // div-by-zero checking option is on, so we should be able to cases found:
+	  	assertEquals(3, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
+	    		&& Preds.isAssertThrowsLine(ArithmeticException.class,z))) ;   
+	}
+	
+	@Test
+	void test_replay_division_by_zero() throws IOException {
+
+		String argz =   "--classpath=" + binClassesDir
+				      + sp + "--classname=" + CUT2.getName()
+				      + sp + "--output-path=" + outputDir 
+				      + sp + "-C=true" // concrete driven to test replay
+				      + sp + "--check-divbyZero"
+				      + sp + "--do-not-close-z3-context=true" // don't close z3 context, or else the next tests will crash
+				      + sp
+				      ;
+	    int exitCode = new CommandLine(new MazeCLI()).execute(argz.split(" ") );
+	    
+	    //assertTrue(interceptor.anyMatch(msg -> msg.contains("#generated") && msg.contains("8"))) ;
+	    
+	    var outputFile = new TxtFileContent(Path.of(outputDir, CUT2.getSimpleName() + "Test.java")) ;
+	    
+	    // div-by-zero checking option is on, so we should be able to cases found:
+	  	assertEquals(4, outputFile.countMatchingLines(z -> ! Preds.isCommentLine(z) 
+	    		&& Preds.isAssertThrowsLine(ArithmeticException.class,z))) ;
+	    
 	    
 	}
 


### PR DESCRIPTION
Small changes to some benchmark classes:

- AckermannPeter: adding a guard to reject negative inputs (would cause the method to go into an infinite loop). In particular the concrete-driven search might generate such inputs, and without the new guard my generate trigger the infinite loop. Note that since the infinite loop happens inside the method under test, Maze cannot intervene to stop it (well... not without some additional instrumentation; maybe future work).
- Method sqrt in FloatStatistics: similar change, adding a guard to reject negative input.